### PR TITLE
[#11] 배포 서버에서 메인 페이지 렌더링 엔드포인트를 찾지 못하는 문제 해결

### DIFF
--- a/src/main/java/bgaebalja/exsherpa/main/MainController.java
+++ b/src/main/java/bgaebalja/exsherpa/main/MainController.java
@@ -1,4 +1,4 @@
-package bgaebalja.exsherpa;
+package bgaebalja.exsherpa.main;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 public class MainController {
-    @GetMapping()
+    @GetMapping("/main.do")
     public String getMainPage() {
         return "main";
     }


### PR DESCRIPTION
## resolve #11

## 변경사항
- MainController 클래스의 패키지를 하위 경로로 이동
- 메인페이지를 렌더링하는 엔드포인트의 경로를 /main.do로 변경

## 배포
- [x] 성공
- [ ] 실패