### PR TITLE
[#11] 배포 서버에서 메인 페이지 렌더링 엔드포인트를 찾지 못하는 문제 해결

### DIFF
--- a/src/main/java/bgaebalja/exsherpa/main/MainController.java
+++ b/src/main/java/bgaebalja/exsherpa/main/MainController.java
@@ -7,6 +7,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 public class MainController {
     @GetMapping("/")
     public String getMainPage() {
-        return "main.jsp";
+        return "/main";
     }
 }


### PR DESCRIPTION
## resolve #11

## 변경사항
- 메인페이지를 렌더링하는 엔드포인트의 반환값을 /main으로 변경

## 배포
- [x] 성공
- [ ] 실패