### PR TITLE
[#25] 엔티티의 일반적인 컬럼을 자동으로 관리하는 BaseEntity와 BaseGeneralEntity 클래스 추가

### DIFF
--- a/src/main/java/bgaebalja/exsherpa/audit/BaseEntity.java
+++ b/src/main/java/bgaebalja/exsherpa/audit/BaseEntity.java
@@ -1,0 +1,31 @@
+package bgaebalja.exsherpa.audit;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@EntityListeners(value = AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/bgaebalja/exsherpa/audit/BaseGeneralEntity.java
+++ b/src/main/java/bgaebalja/exsherpa/audit/BaseGeneralEntity.java
@@ -1,0 +1,30 @@
+package bgaebalja.exsherpa.audit;
+
+import lombok.Getter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+
+import static bgaebalja.exsherpa.util.EntityConstant.BOOLEAN_DEFAULT_FALSE;
+import static javax.persistence.GenerationType.IDENTITY;
+
+
+@EntityListeners(value = AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseGeneralEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = BOOLEAN_DEFAULT_FALSE)
+    private boolean deleteYn;
+
+    protected void deleteEntity() {
+        deleteYn = true;
+    }
+
+    protected void undeleteEntity() {
+        deleteYn = false;
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/util/EntityConstant.java
+++ b/src/main/java/bgaebalja/exsherpa/util/EntityConstant.java
@@ -1,0 +1,5 @@
+package bgaebalja.exsherpa.util;
+
+public class EntityConstant {
+    public static final String BOOLEAN_DEFAULT_FALSE = "boolean default false";
+}


### PR DESCRIPTION
## resolve #25

## 추가사항
- AuditConfig 클래스

### BaseEntity 클래스
- CreatedAt 속성
- ModifiedAt 속성

### BaseGeneralEntity 클래스
- ID 속성
- deleteYn 속성

## 배포
- [x] 성공
- [ ] 실패