### PR TITLE
[#53] subject 페이지에 시험지 목록을 받아오는 기능 추가

### DIFF
--- a/src/main/java/bgaebalja/exsherpa/book/domain/Book.java
+++ b/src/main/java/bgaebalja/exsherpa/book/domain/Book.java
@@ -1,0 +1,34 @@
+package bgaebalja.exsherpa.book.domain;
+
+import bgaebalja.exsherpa.audit.BaseGeneralEntity;
+import bgaebalja.exsherpa.subject.domain.Subject;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Book extends BaseGeneralEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String bookId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String author;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "subject_id")
+    private Subject subject;
+}

--- a/src/main/java/bgaebalja/exsherpa/clazz/domain/Clazz.java
+++ b/src/main/java/bgaebalja/exsherpa/clazz/domain/Clazz.java
@@ -1,0 +1,20 @@
+package bgaebalja.exsherpa.clazz.domain;
+
+import bgaebalja.exsherpa.audit.BaseEntity;
+import lombok.Getter;
+
+import javax.persistence.*;
+
+import static javax.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Table(name = "class")
+@Getter
+public class Clazz extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String name;
+
+}

--- a/src/main/java/bgaebalja/exsherpa/collection/domain/Collection.java
+++ b/src/main/java/bgaebalja/exsherpa/collection/domain/Collection.java
@@ -1,0 +1,40 @@
+package bgaebalja.exsherpa.collection.domain;
+
+import bgaebalja.exsherpa.audit.BaseGeneralEntity;
+import bgaebalja.exsherpa.exam.domain.Exam;
+import bgaebalja.exsherpa.exam.passage.domain.Passage;
+import bgaebalja.exsherpa.question.domain.Question;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import java.util.List;
+
+import static javax.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class Collection extends BaseGeneralEntity {
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "exam_id")
+    private Exam exam;
+
+    @OneToMany(mappedBy = "collection")
+    private List<Question> questions;
+
+    @OneToMany(mappedBy = "collection")
+    private List<Passage> passages;
+
+    @Builder
+    private Collection(Exam exam, List<Question> questions, List<Passage> passages) {
+        this.exam = exam;
+        this.questions = questions;
+        this.passages = passages;
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/collection/domain/GetCollectionResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/collection/domain/GetCollectionResponse.java
@@ -1,0 +1,25 @@
+package bgaebalja.exsherpa.collection.domain;
+
+import bgaebalja.exsherpa.exam.passage.domain.GetPassagesResponse;
+import bgaebalja.exsherpa.question.domain.GetQuestionsResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GetCollectionResponse {
+    private GetPassagesResponse getPassagesResponse;
+    private GetQuestionsResponse getQuestionsResponse;
+
+    @Builder
+    private GetCollectionResponse(GetPassagesResponse getPassagesResponse, GetQuestionsResponse getQuestionsResponse) {
+        this.getPassagesResponse = getPassagesResponse;
+        this.getQuestionsResponse = getQuestionsResponse;
+    }
+
+    public static GetCollectionResponse from(Collection collection) {
+        return GetCollectionResponse.builder()
+                .getPassagesResponse(GetPassagesResponse.from(collection.getPassages()))
+                .getQuestionsResponse(GetQuestionsResponse.from(collection.getQuestions()))
+                .build();
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/collection/domain/GetCollectionsResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/collection/domain/GetCollectionsResponse.java
@@ -1,0 +1,21 @@
+package bgaebalja.exsherpa.collection.domain;
+
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class GetCollectionsResponse {
+    private final List<GetCollectionResponse> getCollectionResponses;
+
+    private GetCollectionsResponse(List<GetCollectionResponse> getCollectionResponses) {
+        this.getCollectionResponses = getCollectionResponses;
+    }
+
+    public static GetCollectionsResponse from(List<Collection> collections) {
+        return new GetCollectionsResponse(
+                collections.stream().map(GetCollectionResponse::from).collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/exam/domain/Exam.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/domain/Exam.java
@@ -1,0 +1,55 @@
+package bgaebalja.exsherpa.exam.domain;
+
+import bgaebalja.exsherpa.audit.BaseGeneralEntity;
+import bgaebalja.exsherpa.book.domain.Book;
+import bgaebalja.exsherpa.collection.domain.Collection;
+import bgaebalja.exsherpa.examination.domain.ExaminationHistory;
+import bgaebalja.exsherpa.user.domain.Users;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+import static javax.persistence.CascadeType.PERSIST;
+import static javax.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class Exam extends BaseGeneralEntity {
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private Users user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "book_id")
+    private Book book;
+
+    @Column(name = "exam_name")
+    private String examName;
+
+    @Column(name = "total_count")
+    private Long totalCount;
+
+    @Column(name = "open_yn")
+    private Boolean openYn;
+
+    @Column(name = "exam_type")
+    private ExamType examType = ExamType.ALL;
+
+    @OneToMany(mappedBy = "exam", cascade = PERSIST)
+    private List<Collection> collections;
+
+    @OneToMany(mappedBy = "exam", cascade = PERSIST)
+    private List<ExaminationHistory> examinationHistories;
+
+    public Exam(Users user, String examName, Long totalCount, Boolean openYn, List<Collection> collections) {
+        this.user = user;
+        this.examName = examName;
+        this.totalCount = totalCount;
+        this.openYn = openYn;
+        this.collections = collections;
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/exam/domain/ExamType.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/domain/ExamType.java
@@ -1,0 +1,25 @@
+package bgaebalja.exsherpa.exam.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ExamType {
+    ALL("A"),
+    QUESTION("Q"),
+    EXPLAIN("E");
+
+    private final String differentiation;
+
+    public static String getDifferentiation(String differentiation) {
+        for (ExamType examType : ExamType.values()) {
+            if (examType.differentiation.equals(differentiation)) {
+                return examType.name();
+            }
+        }
+        throw new IllegalArgumentException();
+    }
+
+
+}

--- a/src/main/java/bgaebalja/exsherpa/exam/domain/GetExamResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/domain/GetExamResponse.java
@@ -1,0 +1,54 @@
+package bgaebalja.exsherpa.exam.domain;
+
+import bgaebalja.exsherpa.collection.domain.GetCollectionsResponse;
+import bgaebalja.exsherpa.examination.domain.GetExaminationHistoriesResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GetExamResponse {
+    private Long id;
+    private String username;
+    private String className;
+    private String grade;
+    private String examName;
+    private String subjectName;
+    private String timeLimit;
+    private GetCollectionsResponse getCollectionsResponse;
+    private GetExaminationHistoriesResponse getExaminationHistoriesResponse;
+
+    @Builder
+    private GetExamResponse(
+            Long id, String username, String className, String grade, String examName,
+            String subjectName, String timeLimit, GetCollectionsResponse getCollectionsResponse,
+            GetExaminationHistoriesResponse getExaminationHistoriesResponse
+    ) {
+        this.id = id;
+        this.username = username;
+        this.className = className;
+        this.grade = grade;
+        this.examName = examName;
+        this.subjectName = subjectName;
+        this.timeLimit = timeLimit;
+        this.getCollectionsResponse = getCollectionsResponse;
+        this.getExaminationHistoriesResponse = getExaminationHistoriesResponse;
+    }
+
+    public static GetExamResponse from(Exam exam) {
+        // TODO: 시간 제한 학년/과목 별로 연동
+        // TODO: 회원에 추가되는 학교 등급과 학년 정보 연동
+        return GetExamResponse.builder()
+                .id(exam.getId())
+                .username(exam.getUser().getUsername())
+//                .className(exam.getUser().getClassName())
+//                .grade(exam.getUser().getGrade())
+                .className("중")
+                .grade("3")
+                .examName(exam.getExamName())
+                .subjectName(exam.getBook().getSubject().getName())
+                .timeLimit("60")
+                .getCollectionsResponse(GetCollectionsResponse.from(exam.getCollections()))
+                .getExaminationHistoriesResponse(GetExaminationHistoriesResponse.from(exam.getExaminationHistories()))
+                .build();
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/exam/domain/GetExamsResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/domain/GetExamsResponse.java
@@ -1,0 +1,27 @@
+package bgaebalja.exsherpa.exam.domain;
+
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class GetExamsResponse {
+    private List<GetExamResponse> getExamResponses;
+
+    private GetExamsResponse(List<GetExamResponse> getExamResponses) {
+        this.getExamResponses = getExamResponses;
+    }
+
+    public static GetExamsResponse from(List<Exam> exams) {
+        return new GetExamsResponse(exams.stream().map(GetExamResponse::from).collect(Collectors.toList()));
+    }
+
+    public int size() {
+        return getExamResponses.size();
+    }
+
+    public GetExamResponse get(int index) {
+        return getExamResponses.get(index);
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/exam/passage/domain/GetPassageResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/passage/domain/GetPassageResponse.java
@@ -1,0 +1,22 @@
+package bgaebalja.exsherpa.exam.passage.domain;
+
+import lombok.Getter;
+
+@Getter
+public class GetPassageResponse {
+    private Long id;
+    private Long passageId;
+    private String html;
+    private String url;
+
+    private GetPassageResponse(Long id, Long passageId, String html, String url) {
+        this.id = id;
+        this.passageId = passageId;
+        this.html = html;
+        this.url = url;
+    }
+
+    public static GetPassageResponse from(Passage passage) {
+        return new GetPassageResponse(passage.getId(), passage.getPassageId(), passage.getHtml(), passage.getUrl());
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/exam/passage/domain/GetPassagesResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/passage/domain/GetPassagesResponse.java
@@ -1,0 +1,21 @@
+package bgaebalja.exsherpa.exam.passage.domain;
+
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class GetPassagesResponse {
+    private final List<GetPassageResponse> getPassageResponses;
+
+    private GetPassagesResponse(List<GetPassageResponse> getPassageResponses) {
+        this.getPassageResponses = getPassageResponses;
+    }
+
+    public static GetPassagesResponse from(List<Passage> passages) {
+        return new GetPassagesResponse(
+                passages.stream().map(GetPassageResponse::from).collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/exam/passage/domain/Passage.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/passage/domain/Passage.java
@@ -1,0 +1,41 @@
+package bgaebalja.exsherpa.exam.passage.domain;
+
+import bgaebalja.exsherpa.audit.BaseGeneralEntity;
+import bgaebalja.exsherpa.collection.domain.Collection;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import static javax.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class Passage extends BaseGeneralEntity {
+    @Column(nullable = false)
+    private Long passageId;
+
+    @Column(nullable = false)
+    private String html;
+
+    @Column(nullable = false)
+    private String url;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "collection_id")
+    private Collection collection;
+
+    @Builder
+    private Passage(Long passageId, String html, String url, Collection collection) {
+        this.passageId = passageId;
+        this.html = html;
+        this.url = url;
+        this.collection = collection;
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/exam/repository/ExamRepository.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/repository/ExamRepository.java
@@ -1,0 +1,15 @@
+package bgaebalja.exsherpa.exam.repository;
+
+import bgaebalja.exsherpa.exam.domain.Exam;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ExamRepository extends JpaRepository<Exam, Long> {
+    Optional<Exam> findById(Long id);
+
+    List<Exam> findByDeleteYnFalseAndOpenYnTrue();
+}

--- a/src/main/java/bgaebalja/exsherpa/exam/service/ExamService.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/service/ExamService.java
@@ -1,0 +1,11 @@
+package bgaebalja.exsherpa.exam.service;
+
+import bgaebalja.exsherpa.exam.domain.Exam;
+
+import java.util.List;
+
+public interface ExamService {
+    List<Exam> getPastExams();
+
+    List<Exam> getBsherpaExams();
+}

--- a/src/main/java/bgaebalja/exsherpa/exam/service/ExamServiceImpl.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/service/ExamServiceImpl.java
@@ -1,0 +1,28 @@
+package bgaebalja.exsherpa.exam.service;
+
+import bgaebalja.exsherpa.exam.domain.Exam;
+import bgaebalja.exsherpa.exam.repository.ExamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 20)
+public class ExamServiceImpl implements ExamService {
+    private final ExamRepository examRepository;
+
+    @Override
+    public List<Exam> getPastExams() {
+        return examRepository.findByDeleteYnFalseAndOpenYnTrue();
+    }
+
+    @Override
+    public List<Exam> getBsherpaExams() {
+        return examRepository.findByDeleteYnFalseAndOpenYnTrue();
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/examination/controller/ExaminationController.java
+++ b/src/main/java/bgaebalja/exsherpa/examination/controller/ExaminationController.java
@@ -1,6 +1,9 @@
 package bgaebalja.exsherpa.examination.controller;
 
+import bgaebalja.exsherpa.exam.domain.GetExamsResponse;
+import bgaebalja.exsherpa.exam.service.ExamService;
 import bgaebalja.exsherpa.examination.domain.ExamInformationResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,7 +12,10 @@ import org.springframework.web.servlet.ModelAndView;
 
 @Controller
 @RequestMapping("/user/exam")
+@RequiredArgsConstructor
 public class ExaminationController {
+    private final ExamService examService;
+
     @GetMapping("/user-exam-cbt")
     public ModelAndView getPracticeInformationPage(@RequestParam("school_level") String schoolLevel) {
         return new ModelAndView("user/exam/user-exam-cbt", "schoolLevel", schoolLevel);
@@ -31,11 +37,16 @@ public class ExaminationController {
             @RequestParam("exam_round") String examRound,
             @RequestParam("year") String year
     ) {
-        // TODO: 데이터베이스에서 시험지 ID를 가져 오는 로직 추가
-        return new ModelAndView(
-                "user/exam/user-exam-subject",
-                "examInformationResponse", ExamInformationResponse.of(schoolLevel, examRound, year)
-        );
+        ModelAndView modelAndView = new ModelAndView("user/exam/user-exam-subject");
+        modelAndView.addObject("examInformationResponse", ExamInformationResponse.of(schoolLevel, examRound, year));
+
+        if (examRound.equals("1")) {
+            modelAndView.addObject("getExamsResponse", GetExamsResponse.from(examService.getPastExams()));
+            return modelAndView;
+        }
+
+        modelAndView.addObject("getExamsResponse", GetExamsResponse.from(examService.getBsherpaExams()));
+        return modelAndView;
     }
 
     @GetMapping("/user-exam-sound")

--- a/src/main/java/bgaebalja/exsherpa/examination/domain/ExaminationHistory.java
+++ b/src/main/java/bgaebalja/exsherpa/examination/domain/ExaminationHistory.java
@@ -1,8 +1,9 @@
-package bgaebalja.exsherpa.examinationhistory.domain;
+package bgaebalja.exsherpa.examination.domain;
 
 import bgaebalja.exsherpa.audit.BaseGeneralEntity;
 import bgaebalja.exsherpa.exam.domain.Exam;
 import bgaebalja.exsherpa.user.domain.Users;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
@@ -16,9 +17,10 @@ import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
+@Getter
 public class ExaminationHistory extends BaseGeneralEntity {
     @Column(nullable = false, columnDefinition = BOOLEAN_DEFAULT_FALSE)
-    private boolean SolvedYn;
+    private boolean solvedYn;
 
     private short answerCount;
 

--- a/src/main/java/bgaebalja/exsherpa/examination/domain/GetExaminationHistoriesResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/examination/domain/GetExaminationHistoriesResponse.java
@@ -1,0 +1,21 @@
+package bgaebalja.exsherpa.examination.domain;
+
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class GetExaminationHistoriesResponse {
+    private List<GetExaminationHistoryResponse> getExaminationHistoryResponses;
+
+    private GetExaminationHistoriesResponse(List<GetExaminationHistoryResponse> getExaminationHistoryResponses) {
+        this.getExaminationHistoryResponses = getExaminationHistoryResponses;
+    }
+
+    public static GetExaminationHistoriesResponse from(List<ExaminationHistory> examinationHistories) {
+        return new GetExaminationHistoriesResponse(
+                examinationHistories.stream().map(GetExaminationHistoryResponse::from).collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/examination/domain/GetExaminationHistoryResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/examination/domain/GetExaminationHistoryResponse.java
@@ -1,0 +1,15 @@
+package bgaebalja.exsherpa.examination.domain;
+
+public class GetExaminationHistoryResponse {
+    private boolean isSolved;
+    private short answerCount;
+
+    private GetExaminationHistoryResponse(boolean isSolved, short answerCount) {
+        this.isSolved = isSolved;
+        this.answerCount = answerCount;
+    }
+
+    public static GetExaminationHistoryResponse from(ExaminationHistory examinationHistory) {
+        return new GetExaminationHistoryResponse(examinationHistory.isSolvedYn(), examinationHistory.getAnswerCount());
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/examination/domain/SolvedQuestion.java
+++ b/src/main/java/bgaebalja/exsherpa/examination/domain/SolvedQuestion.java
@@ -1,4 +1,4 @@
-package bgaebalja.exsherpa.examinationhistory.domain;
+package bgaebalja.exsherpa.examination.domain;
 
 import bgaebalja.exsherpa.audit.BaseGeneralEntity;
 import bgaebalja.exsherpa.question.domain.Question;

--- a/src/main/java/bgaebalja/exsherpa/passage/domain/GetPassageResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/passage/domain/GetPassageResponse.java
@@ -1,0 +1,22 @@
+package bgaebalja.exsherpa.passage.domain;
+
+import lombok.Getter;
+
+@Getter
+public class GetPassageResponse {
+    private Long id;
+    private Long passageId;
+    private String html;
+    private String url;
+
+    private GetPassageResponse(Long id, Long passageId, String html, String url) {
+        this.id = id;
+        this.passageId = passageId;
+        this.html = html;
+        this.url = url;
+    }
+
+    public static GetPassageResponse from(Passage passage) {
+        return new GetPassageResponse(passage.getId(), passage.getPassageId(), passage.getHtml(), passage.getUrl());
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/passage/domain/GetPassagesResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/passage/domain/GetPassagesResponse.java
@@ -1,0 +1,21 @@
+package bgaebalja.exsherpa.passage.domain;
+
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class GetPassagesResponse {
+    private final List<GetPassageResponse> getPassageResponses;
+
+    private GetPassagesResponse(List<GetPassageResponse> getPassageResponses) {
+        this.getPassageResponses = getPassageResponses;
+    }
+
+    public static GetPassagesResponse from(List<Passage> passages) {
+        return new GetPassagesResponse(
+                passages.stream().map(GetPassageResponse::from).collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/passage/domain/Passage.java
+++ b/src/main/java/bgaebalja/exsherpa/passage/domain/Passage.java
@@ -1,0 +1,41 @@
+package bgaebalja.exsherpa.passage.domain;
+
+import bgaebalja.exsherpa.audit.BaseGeneralEntity;
+import bgaebalja.exsherpa.collection.domain.Collection;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import static javax.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class Passage extends BaseGeneralEntity {
+    @Column(nullable = false)
+    private Long passageId;
+
+    @Column(nullable = false)
+    private String html;
+
+    @Column(nullable = false)
+    private String url;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "collection_id")
+    private Collection collection;
+
+    @Builder
+    private Passage(Long passageId, String html, String url, Collection collection) {
+        this.passageId = passageId;
+        this.html = html;
+        this.url = url;
+        this.collection = collection;
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/question/domain/Difficulty.java
+++ b/src/main/java/bgaebalja/exsherpa/question/domain/Difficulty.java
@@ -1,0 +1,30 @@
+package bgaebalja.exsherpa.question.domain;
+
+import bgaebalja.exsherpa.question.exception.DifficultyNotFoundException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import static bgaebalja.exsherpa.question.exception.ExceptionMessage.DIFFICULTY_NOT_FOUND_EXCEPTION_MESSAGE;
+
+@RequiredArgsConstructor
+@Getter
+public enum Difficulty {
+    VERY_EASY("01", "최하"),
+    EASY("02", "하"),
+    NORMAL("03", "중"),
+    HARD("04", "상"),
+    VERY_HARD("05", "최상");
+
+    private final String code;
+    private final String name;
+
+    public static String getNameByCode(String code) {
+        for (Difficulty difficulty : Difficulty.values()) {
+            if (difficulty.getCode().equals(code)) {
+                return difficulty.getName();
+            }
+        }
+
+        throw new DifficultyNotFoundException(String.format(DIFFICULTY_NOT_FOUND_EXCEPTION_MESSAGE, code));
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/question/domain/DifficultyDeserializer.java
+++ b/src/main/java/bgaebalja/exsherpa/question/domain/DifficultyDeserializer.java
@@ -1,0 +1,25 @@
+package bgaebalja.exsherpa.question.domain;
+
+import bgaebalja.exsherpa.question.exception.DifficultyNotFoundException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+
+public class DifficultyDeserializer extends JsonDeserializer<Difficulty> {
+    @Override
+    public Difficulty deserialize(JsonParser jsonParser, DeserializationContext context)
+            throws IOException, JsonProcessingException {
+        String value = jsonParser.getText();
+
+        for (Difficulty difficulty : Difficulty.values()) {
+            if (difficulty.getName().equals(value) || difficulty.getCode().equals(value)) {
+                return difficulty;
+            }
+        }
+
+        throw new DifficultyNotFoundException(String.format("Difficulty not found for value: %s", value));
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/question/domain/GetQuestionResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/question/domain/GetQuestionResponse.java
@@ -1,0 +1,72 @@
+package bgaebalja.exsherpa.question.domain;
+
+import bgaebalja.exsherpa.collection.domain.Collection;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GetQuestionResponse {
+    private Long itemId;
+    private String descriptionUrl;
+    private QuestionType questionType;
+    private Difficulty difficulty;
+    private String answer;
+    private String answerUrl;
+    private int errorReportCount;
+    private boolean blockYn;
+    private Collection collection;
+    private Integer placementNumber;
+    private String largeChapterCode;
+    private String largeChapterName;
+    private String mediumChapterCode;
+    private String mediumChapterName;
+    private String smallChapterCode;
+    private String smallChapterName;
+    private String topicChapterCode;
+    private String topicChapterName;
+
+    @Builder
+    private GetQuestionResponse(
+            Long itemId, String descriptionUrl, QuestionType questionType, Difficulty difficulty, String answer,
+            String answerUrl, int errorReportCount, boolean blockYn, Collection collection, Integer placementNumber,
+            String largeChapterCode, String largeChapterName, String mediumChapterCode, String mediumChapterName,
+            String smallChapterCode, String smallChapterName, String topicChapterCode, String topicChapterName
+    ) {
+        this.itemId = itemId;
+        this.descriptionUrl = descriptionUrl;
+        this.questionType = questionType;
+        this.difficulty = difficulty;
+        this.answer = answer;
+        this.answerUrl = answerUrl;
+        this.errorReportCount = errorReportCount;
+        this.blockYn = blockYn;
+        this.collection = collection;
+        this.placementNumber = placementNumber;
+        this.largeChapterCode = largeChapterCode;
+        this.largeChapterName = largeChapterName;
+        this.mediumChapterCode = mediumChapterCode;
+        this.mediumChapterName = mediumChapterName;
+        this.smallChapterCode = smallChapterCode;
+        this.smallChapterName = smallChapterName;
+        this.topicChapterCode = topicChapterCode;
+        this.topicChapterName = topicChapterName;
+    }
+
+    public static GetQuestionResponse from(Question question) {
+        return GetQuestionResponse.builder()
+                .itemId(question.getItemId())
+                .descriptionUrl(question.getDescriptionUrl())
+                .questionType(question.getQuestionType())
+                .difficulty(question.getDifficulty())
+                .answer(question.getAnswer())
+                .answerUrl(question.getAnswerUrl())
+                .errorReportCount(question.getErrorReportCount())
+                .blockYn(question.isBlockYn())
+                .collection(question.getCollection())
+                .placementNumber(question.getPlacementNumber())
+                .largeChapterCode(question.getLargeChapterCode())
+                .largeChapterName(question.getLargeChapterName())
+                .mediumChapterCode(question.getMediumChapterCode())
+                .build();
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/question/domain/GetQuestionsResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/question/domain/GetQuestionsResponse.java
@@ -1,0 +1,21 @@
+package bgaebalja.exsherpa.question.domain;
+
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class GetQuestionsResponse {
+    private final List<GetQuestionResponse> getQuestionResponses;
+
+    private GetQuestionsResponse(List<GetQuestionResponse> getQuestionResponses) {
+        this.getQuestionResponses = getQuestionResponses;
+    }
+
+    public static GetQuestionsResponse from(List<Question> questions) {
+        return new GetQuestionsResponse(
+                questions.stream().map(GetQuestionResponse::from).collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/question/domain/Question.java
+++ b/src/main/java/bgaebalja/exsherpa/question/domain/Question.java
@@ -1,0 +1,107 @@
+package bgaebalja.exsherpa.question.domain;
+
+import bgaebalja.exsherpa.audit.BaseGeneralEntity;
+import bgaebalja.exsherpa.collection.domain.Collection;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static bgaebalja.exsherpa.util.EntityConstant.BOOLEAN_DEFAULT_FALSE;
+import static javax.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class Question extends BaseGeneralEntity {
+    @Column(nullable = false)
+    private Long itemId;
+
+    @Column(nullable = false)
+    private String descriptionUrl;
+
+    // enum으로 저장
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @JsonDeserialize(using = QuestionTypeDeserializer.class)
+    private QuestionType questionType;
+
+    // enum으로 저장
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @JsonDeserialize(using = DifficultyDeserializer.class)
+    private Difficulty difficulty;
+
+    // 서술형인 경우 "해설 참조"로 저장, 정답 채점 대상에서 제외
+    @Column(nullable = false)
+    private String answer;
+
+    @Column(nullable = false)
+    private String answerUrl;
+
+    @Column(nullable = false)
+    private int errorReportCount;
+
+    @Column(nullable = false, columnDefinition = BOOLEAN_DEFAULT_FALSE)
+    private boolean blockYn;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "collection_id")
+    private Collection collection;
+
+    // 배치순서 Column 추가, Chapter -> Question 안으로 넣게 수정
+    @Column(name = "placement_number")
+    private Integer placementNumber;
+
+    @Column(name = "large_chapter_code")
+    private String largeChapterCode;
+
+    @Column(name = "large_chapter_name")
+    private String largeChapterName;
+
+    @Column(name = "medium_chapter_code")
+    private String mediumChapterCode;
+
+    @Column(name = "medium_chapter_name")
+    private String mediumChapterName;
+
+    @Column(name = "small_chapter_code")
+    private String smallChapterCode;
+
+    @Column(name = "small_chapter_name")
+    private String smallChapterName;
+
+    @Column(name = "topic_chapter_code")
+    private String topicChapterCode;
+
+    @Column(name = "topic_chapter_name")
+    private String topicChapterName;
+
+    @Builder
+    private Question(
+            Long itemId, String descriptionUrl, QuestionType questionType,
+            Difficulty difficulty, String answer, String answerUrl, Collection collection, Integer placementNumber,
+            String largeChapterCode, String largeChapterName, String mediumChapterCode, String mediumChapterName,
+            String smallChapterCode, String smallChapterName, String topicChapterCode, String topicChapterName
+    ) {
+        this.itemId = itemId;
+        this.descriptionUrl = descriptionUrl;
+        this.questionType = questionType;
+        this.difficulty = difficulty;
+        this.answer = answer;
+        this.answerUrl = answerUrl;
+        this.collection = collection;
+        this.placementNumber = placementNumber;
+        this.largeChapterCode = largeChapterCode;
+        this.largeChapterName = largeChapterName;
+        this.mediumChapterCode = mediumChapterCode;
+        this.mediumChapterName = mediumChapterName;
+        this.smallChapterCode = smallChapterCode;
+        this.smallChapterName = smallChapterName;
+        this.topicChapterCode = topicChapterCode;
+        this.topicChapterName = topicChapterName;
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/question/domain/QuestionType.java
+++ b/src/main/java/bgaebalja/exsherpa/question/domain/QuestionType.java
@@ -1,0 +1,54 @@
+package bgaebalja.exsherpa.question.domain;
+
+import bgaebalja.exsherpa.question.exception.QuestionTypeNotFoundException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import static bgaebalja.exsherpa.question.exception.ExceptionMessage.QUESTION_TYPE_NOT_FOUND_EXCEPTION_MESSAGE;
+
+/**
+ * 자유선지형: 선택지 개수만큼의 보기 튜플 생성
+ * 2지 선택: 두 개의 보기 튜플 생성
+ * 3지 선택: 세 개의 보기 튜플 생성
+ * 4지 선택: 네 개의 보기 튜플 생성
+ * 5지 선택: 다섯 개의 보기 튜플 생성
+ * 단답형, 논술형, 선택채움형, 서술형, 드래그 드랍, 영역 선택형, 선잇기형, 기타: 보기 튜플 생성 안 함
+ * 서술형, 기타: 정답 채점 제외
+ */
+@RequiredArgsConstructor
+@Getter
+public enum QuestionType {
+    FREE_CHOICE("10", "자유선지형"),
+    CHOICE_FROM_TWO("20", "2지 선택"),
+    CHOICE_FROM_THREE("30", "3지 선택"),
+    CHOICE_FROM_FOUR("40", "4지 선택"),
+    CHOICE_FROM_FIVE("50", "5지 선택"),
+    ORDERED_SUBJECTIVE("60", "단답 유순형"),
+    UNORDERED_SUBJECTIVE("61", "단답 무순형"),
+    GROUPED_SUBJECTIVE("63", "단답 그룹형"),
+    ESSAY("70", "논술형"),
+    FILLING_SELECTION("84", "선택채움형"),
+    DESCRIPTIVE("85", "서술형"),
+    DRAG_DROP("86", "드래그 드랍"),
+    AREA_SELECTION("87", "영역 선택형"),
+    CONNECTING_LINE("88", "선잇기형"),
+    ETC("99", "기타");
+
+    private final String code;
+    private final String name;
+
+    // 서술형인 경우 정답 채점 제외
+    public boolean isDescriptive() {
+        return this == DESCRIPTIVE;
+    }
+
+    public static String getNameByCode(String code) {
+        for (QuestionType questionType : QuestionType.values()) {
+            if (questionType.getCode().equals(code)) {
+                return questionType.getName();
+            }
+        }
+
+        throw new QuestionTypeNotFoundException(String.format(QUESTION_TYPE_NOT_FOUND_EXCEPTION_MESSAGE, code));
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/question/domain/QuestionTypeDeserializer.java
+++ b/src/main/java/bgaebalja/exsherpa/question/domain/QuestionTypeDeserializer.java
@@ -1,0 +1,49 @@
+package bgaebalja.exsherpa.question.domain;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+
+public class QuestionTypeDeserializer extends JsonDeserializer<QuestionType> {
+    @Override
+    public QuestionType deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
+        String value = jsonParser.getText().trim(); // 공백 제거
+
+        switch (value) {
+            case "자유선지형":
+                return QuestionType.FREE_CHOICE;
+            case "2지 선택":
+                return QuestionType.CHOICE_FROM_TWO;
+            case "3지 선택":
+                return QuestionType.CHOICE_FROM_THREE;
+            case "4지 선택":
+                return QuestionType.CHOICE_FROM_FOUR;
+            case "5지 선택":
+                return QuestionType.CHOICE_FROM_FIVE;
+            case "단답 유순형":
+                return QuestionType.ORDERED_SUBJECTIVE;
+            case "단답 무순형":
+                return QuestionType.UNORDERED_SUBJECTIVE;
+            case "단답 그룹형":
+                return QuestionType.GROUPED_SUBJECTIVE;
+            case "논술형":
+                return QuestionType.ESSAY;
+            case "선택채움형":
+                return QuestionType.FILLING_SELECTION;
+            case "서술형":
+                return QuestionType.DESCRIPTIVE;
+            case "드래그 드랍":
+                return QuestionType.DRAG_DROP;
+            case "영역 선택형":
+                return QuestionType.AREA_SELECTION;
+            case "선잇기형":
+                return QuestionType.CONNECTING_LINE;
+            case "기타":
+                return QuestionType.ETC;
+            default:
+                throw new IllegalArgumentException("Unknown value: " + value);
+        }
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/question/exception/DifficultyNotFoundException.java
+++ b/src/main/java/bgaebalja/exsherpa/question/exception/DifficultyNotFoundException.java
@@ -1,0 +1,9 @@
+package bgaebalja.exsherpa.question.exception;
+
+import javax.persistence.EntityNotFoundException;
+
+public class DifficultyNotFoundException extends EntityNotFoundException {
+    public DifficultyNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/question/exception/ExceptionMessage.java
+++ b/src/main/java/bgaebalja/exsherpa/question/exception/ExceptionMessage.java
@@ -1,0 +1,8 @@
+package bgaebalja.exsherpa.question.exception;
+
+public class ExceptionMessage {
+    public static final String QUESTION_TYPE_NOT_FOUND_EXCEPTION_MESSAGE
+            = "해당 문제 유형을 찾을 수 없습니다. 전송된 문제 코드 또는 이름: %s";
+    public static final String DIFFICULTY_NOT_FOUND_EXCEPTION_MESSAGE
+            = "해당 난이도를 찾을 수 없습니다. 전송된 난이도 코드 또는 이름: %s";
+}

--- a/src/main/java/bgaebalja/exsherpa/question/exception/QuestionTypeNotFoundException.java
+++ b/src/main/java/bgaebalja/exsherpa/question/exception/QuestionTypeNotFoundException.java
@@ -1,0 +1,9 @@
+package bgaebalja.exsherpa.question.exception;
+
+import javax.persistence.EntityNotFoundException;
+
+public class QuestionTypeNotFoundException extends EntityNotFoundException {
+    public QuestionTypeNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/subject/domain/Subject.java
+++ b/src/main/java/bgaebalja/exsherpa/subject/domain/Subject.java
@@ -1,0 +1,26 @@
+package bgaebalja.exsherpa.subject.domain;
+
+import bgaebalja.exsherpa.audit.BaseEntity;
+import bgaebalja.exsherpa.clazz.domain.Clazz;
+import lombok.Getter;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Getter
+public class Subject extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String code;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "class_id")
+    private Clazz clazz;
+}


### PR DESCRIPTION
## resolve #53

## 작업내용

### 등급
- Clazz

### 교재
- Book

### 과목
- Subject

### 시험
- Exam
- ExamType
- GetExamsResponse
- GetExamResponse
- ExamService
- ExamServiceImpl
- ExamRepository
 
### 문제풀이
- ExaminationController
- ExaminationHistory
- GetExaminationHistoriesResponse
- GetExaminationHistoryResponse
- SolvedQuestion

### 지문 + 문제
- Collection
- GetCollectionsResponse
- GetCollectionResponse

### 지문
- GetPassagesResponse
- GetPassageResponse
- Passage

### 문제
- Difficulty
- DifficultyDeserializer
- GetQuestionsResponse
- GetQuestionResponse
- Question
- QuestionType
- QuestionTypeDeserializer
- DifficultyNotFoundException
- ExceptionMessage
- QuestionTypeNotFoundException

## 배포
- [x] 성공
- [ ] 실패