### PR TITLE
[#60] 문제풀이 페이지에 선택한 시험지의 정보와 문제 목록을 받아오는 기능 추가

### DIFF
--- a/src/main/java/bgaebalja/exsherpa/exam/exception/ExamNotFoundException.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/exception/ExamNotFoundException.java
@@ -1,0 +1,9 @@
+package bgaebalja.exsherpa.exam.exception;
+
+import javax.persistence.EntityNotFoundException;
+
+public class ExamNotFoundException extends EntityNotFoundException {
+    public ExamNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/exam/exception/ExceptionMessage.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/exception/ExceptionMessage.java
@@ -1,0 +1,5 @@
+package bgaebalja.exsherpa.exam.exception;
+
+public class ExceptionMessage {
+    public static final String EXAM_NOT_FOUND_EXCEPTION_MESSAGE = "해당하는 시험지를 찾을 수 없습니다. 전송된 ID: %d";
+}

--- a/src/main/java/bgaebalja/exsherpa/exam/repository/ExamRepository.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/repository/ExamRepository.java
@@ -12,4 +12,6 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     Optional<Exam> findById(Long id);
 
     List<Exam> findByDeleteYnFalseAndOpenYnTrue();
+
+    Optional<Exam> findByIdAndDeleteYnFalse(Long examId);
 }

--- a/src/main/java/bgaebalja/exsherpa/exam/service/ExamService.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/service/ExamService.java
@@ -8,4 +8,6 @@ public interface ExamService {
     List<Exam> getPastExams();
 
     List<Exam> getBsherpaExams();
+
+    Exam getExam(Long examId);
 }

--- a/src/main/java/bgaebalja/exsherpa/exam/service/ExamServiceImpl.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/service/ExamServiceImpl.java
@@ -1,6 +1,7 @@
 package bgaebalja.exsherpa.exam.service;
 
 import bgaebalja.exsherpa.exam.domain.Exam;
+import bgaebalja.exsherpa.exam.exception.ExamNotFoundException;
 import bgaebalja.exsherpa.exam.repository.ExamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -8,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static bgaebalja.exsherpa.exam.exception.ExceptionMessage.EXAM_NOT_FOUND_EXCEPTION_MESSAGE;
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
 @Service
@@ -24,5 +26,11 @@ public class ExamServiceImpl implements ExamService {
     @Override
     public List<Exam> getBsherpaExams() {
         return examRepository.findByDeleteYnFalseAndOpenYnTrue();
+    }
+
+    @Override
+    public Exam getExam(Long examId) {
+        return examRepository.findByIdAndDeleteYnFalse(examId)
+                .orElseThrow(() -> new ExamNotFoundException(String.format(EXAM_NOT_FOUND_EXCEPTION_MESSAGE, examId)));
     }
 }

--- a/src/main/java/bgaebalja/exsherpa/examination/controller/ExaminationController.java
+++ b/src/main/java/bgaebalja/exsherpa/examination/controller/ExaminationController.java
@@ -1,8 +1,10 @@
 package bgaebalja.exsherpa.examination.controller;
 
+import bgaebalja.exsherpa.exam.domain.GetExamResponse;
 import bgaebalja.exsherpa.exam.domain.GetExamsResponse;
 import bgaebalja.exsherpa.exam.service.ExamService;
 import bgaebalja.exsherpa.examination.domain.ExamInformationResponse;
+import bgaebalja.exsherpa.util.FormatConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -98,8 +100,10 @@ public class ExaminationController {
 
     @GetMapping("/exam-view")
     public ModelAndView getActualTestPage(@RequestParam(value = "exam_id") String examId) {
-        // TODO: 데이터베이스에서 시험지와 문제 목록 가져 오기
         // TODO: 멀티스레드 시간 측정
-        return new ModelAndView("exam/exam-view", "examId", examId);
+        GetExamResponse getExamResponse
+                = GetExamResponse.from(examService.getExam(FormatConverter.parseToLong(examId)));
+
+        return new ModelAndView("exam/exam-view", "getExamResponse", getExamResponse);
     }
 }


### PR DESCRIPTION
## resolve #60

## 추가사항
- 시험지 ID를 통해 시험지 조회 요청
- 시험지 조회 비즈니스 로직
- 데이터베이스에서 시험지 조회
- 시험지가 존재하지 않을 시 EntityNotFoundException 클래스를 상속하는 ExamNotFoundException 예외 발생
- 시험지 데이터를 문제풀이 페이지에 전송

## 배포
- [ ] 성공
- [ ] 실패