### PR TITLE
[#111] 기출 시험지 목록과 커스텀 시험지 목록을 구분하는 기능 추가

### DIFF
--- a/src/main/java/bgaebalja/exsherpa/exam/domain/Exam.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/domain/Exam.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import java.util.List;
 
+import static bgaebalja.exsherpa.util.EntityConstant.BOOLEAN_DEFAULT_FALSE;
 import static javax.persistence.CascadeType.PERSIST;
 import static javax.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
@@ -27,26 +28,20 @@ public class Exam extends BaseGeneralEntity {
     @JoinColumn(name = "book_id")
     private Book book;
 
-    @Column(name = "exam_name")
+    @Column(nullable = false)
     private String examName;
 
-    @Column(name = "total_count")
     private Long totalCount;
 
-    @Column(name = "open_yn")
-    private Boolean openYn;
+    @Column(nullable = false, columnDefinition = BOOLEAN_DEFAULT_FALSE)
+    private boolean customYn;
+
+    @Column(nullable = false, columnDefinition = BOOLEAN_DEFAULT_FALSE)
+    private boolean openYn;
 
     @OneToMany(mappedBy = "exam", cascade = PERSIST)
     private List<Collection> collections;
 
     @OneToMany(mappedBy = "exam", cascade = PERSIST)
     private List<ExaminationHistory> examinationHistories;
-
-    public Exam(Users user, String examName, Long totalCount, Boolean openYn, List<Collection> collections) {
-        this.user = user;
-        this.examName = examName;
-        this.totalCount = totalCount;
-        this.openYn = openYn;
-        this.collections = collections;
-    }
 }

--- a/src/main/java/bgaebalja/exsherpa/exam/repository/ExamRepository.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/repository/ExamRepository.java
@@ -13,7 +13,9 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
 
     List<Exam> findByDeleteYnFalseAndOpenYnTrue();
 
-    List<Exam> findByUserIdAndDeleteYnFalseAndOpenYnTrue(Long userId);
+    List<Exam> findByUserIdAndCustomYnFalseAndDeleteYnFalseAndOpenYnTrue(Long userId);
+
+    List<Exam> findByUserIdAndCustomYnTrueAndDeleteYnFalseAndOpenYnTrue(Long userId);
 
     Optional<Exam> findByIdAndDeleteYnFalse(Long examId);
 }

--- a/src/main/java/bgaebalja/exsherpa/exam/service/ExamServiceImpl.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/service/ExamServiceImpl.java
@@ -25,14 +25,14 @@ public class ExamServiceImpl implements ExamService {
     public List<Exam> getPastExams(String email) {
         Users user = userRepository.getUserWithRoles(email);
 
-        return examRepository.findByUserIdAndDeleteYnFalseAndOpenYnTrue(user.getId());
+        return examRepository.findByUserIdAndCustomYnFalseAndDeleteYnFalseAndOpenYnTrue(user.getId());
     }
 
     @Override
     public List<Exam> getBsherpaExams(String email) {
         Users user = userRepository.getUserWithRoles(email);
 
-        return examRepository.findByUserIdAndDeleteYnFalseAndOpenYnTrue(user.getId());
+        return examRepository.findByUserIdAndCustomYnTrueAndDeleteYnFalseAndOpenYnTrue(user.getId());
     }
 
     @Override

--- a/src/main/webapp/WEB-INF/views/exam/exam-view.jsp
+++ b/src/main/webapp/WEB-INF/views/exam/exam-view.jsp
@@ -473,7 +473,6 @@
                     }
                 })
                 .then(data => {
-                    // TODO: 학교 등급과 시험 종류(기출, B셀파 문제), 연도 정보 실제 데이터 추가
                     const {schoolLevel, examRound, year, examId, examinationSequence} = data;
 
                     alert("시험이 제출되었습니다.");

--- a/src/main/webapp/WEB-INF/views/user/exam/user-exam-subject.jsp
+++ b/src/main/webapp/WEB-INF/views/user/exam/user-exam-subject.jsp
@@ -96,11 +96,13 @@
                                                     <col width="20%">
                                                     <col width="10%">
                                                     <col width="10%">
+                                                    <col width="10%">
                                                 </colgroup>
                                                 <thead>
                                                 <tr>
                                                     <th scope="col" class="first">순번</th>
                                                     <th scope="col">과목</th>
+                                                    <th scope="col">시험지명</th>
                                                     <th scope="col">시험 시간</th>
                                                     <th scope="col">문항 수</th>
                                                     <th scope="col">시험 응시</th>
@@ -123,6 +125,7 @@
                                                                 <c:otherwise>-</c:otherwise>
                                                             </c:choose>
                                                         </td>
+                                                        <td>${exam.examName}</td>
                                                         <td>${exam.timeLimit}분</td>
                                                         <td>${exam.size}문항</td>
                                                         <td>


### PR DESCRIPTION
## resolve #111

## 추가사항
- 시험지 목록 조회 비즈니스 로직
- 데이터베이스에서 시험지 목록 조회

## 배포
- [x] 성공
- [ ] 실패