### PR TITLE
[#113] 중단했던 시험을 이어서 응시하는 기능 추가, Redis Cache 적용

### DIFF
--- a/src/main/java/bgaebalja/exsherpa/collection/domain/GetCollectionResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/collection/domain/GetCollectionResponse.java
@@ -1,5 +1,6 @@
 package bgaebalja.exsherpa.collection.domain;
 
+import bgaebalja.exsherpa.examination.domain.GetExaminationHistoryResponse;
 import bgaebalja.exsherpa.passage.domain.GetPassagesResponse;
 import bgaebalja.exsherpa.question.domain.GetQuestionsResponse;
 import bgaebalja.exsherpa.util.FormatValidator;
@@ -26,6 +27,23 @@ public class GetCollectionResponse {
         return GetCollectionResponse.builder()
                 .getPassagesResponse(getPassagesResponse)
                 .getQuestionsResponse(GetQuestionsResponse.from(collection.getQuestions()))
+                .build();
+    }
+
+    public static GetCollectionResponse from(
+            Collection collection, GetExaminationHistoryResponse cachedExaminationHistory
+    ) {
+        GetPassagesResponse getPassagesResponse = null;
+        if (FormatValidator.hasValue(collection.getPassages())) {
+            getPassagesResponse = GetPassagesResponse.from(collection.getPassages());
+        }
+
+        return GetCollectionResponse.builder()
+                .getPassagesResponse(getPassagesResponse)
+                .getQuestionsResponse(
+                        GetQuestionsResponse.from(collection.getQuestions(),
+                                cachedExaminationHistory.getGetSolvedQuestionsResponse())
+                )
                 .build();
     }
 

--- a/src/main/java/bgaebalja/exsherpa/collection/domain/GetCollectionsResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/collection/domain/GetCollectionsResponse.java
@@ -1,5 +1,6 @@
 package bgaebalja.exsherpa.collection.domain;
 
+import bgaebalja.exsherpa.examination.domain.GetExaminationHistoryResponse;
 import lombok.Getter;
 
 import java.util.List;
@@ -16,6 +17,16 @@ public class GetCollectionsResponse {
     public static GetCollectionsResponse from(List<Collection> collections) {
         return new GetCollectionsResponse(
                 collections.stream().map(GetCollectionResponse::from).collect(Collectors.toList())
+        );
+    }
+
+    public static GetCollectionsResponse from(
+            List<Collection> collections, GetExaminationHistoryResponse cachedExaminationHistory
+    ) {
+        return new GetCollectionsResponse(
+                collections.stream()
+                        .map((collection) -> GetCollectionResponse.from(collection, cachedExaminationHistory))
+                        .collect(Collectors.toList())
         );
     }
 

--- a/src/main/java/bgaebalja/exsherpa/configuration/CacheConfig.java
+++ b/src/main/java/bgaebalja/exsherpa/configuration/CacheConfig.java
@@ -1,0 +1,80 @@
+package bgaebalja.exsherpa.configuration;
+
+import bgaebalja.exsherpa.hibernate.HibernateCollectionMixIn;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.Collection;
+
+import static org.springframework.data.redis.cache.RedisCacheConfiguration.defaultCacheConfig;
+
+@Configuration
+@EnableCaching
+@RequiredArgsConstructor
+public class CacheConfig {
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Value("${spring.redis.password}")
+    private String password;
+
+    private ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+
+        mapper.registerModule(new Jdk8Module());
+        mapper.registerModule(new Hibernate5Module());
+        mapper.registerModule(new JavaTimeModule());
+
+        mapper.addMixIn(Collection.class, HibernateCollectionMixIn.class);
+
+        return mapper;
+    }
+
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext
+                        .SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext
+                        .SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper())))
+                .entryTtl(defaultCacheConfig().entryTtl(Duration.ofDays(1)).getTtl());
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(password);
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/exam/domain/Exam.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/domain/Exam.java
@@ -44,4 +44,7 @@ public class Exam extends BaseGeneralEntity {
 
     @OneToMany(mappedBy = "exam", cascade = PERSIST)
     private List<ExaminationHistory> examinationHistories;
+
+    public void addStatus() {
+    }
 }

--- a/src/main/java/bgaebalja/exsherpa/exam/domain/GetExamResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/domain/GetExamResponse.java
@@ -2,8 +2,11 @@ package bgaebalja.exsherpa.exam.domain;
 
 import bgaebalja.exsherpa.collection.domain.Collection;
 import bgaebalja.exsherpa.collection.domain.GetCollectionsResponse;
+import bgaebalja.exsherpa.examination.domain.ExaminationHistory;
 import bgaebalja.exsherpa.examination.domain.GetExaminationHistoriesResponse;
+import bgaebalja.exsherpa.examination.domain.GetExaminationHistoryResponse;
 import bgaebalja.exsherpa.util.FormatConverter;
+import bgaebalja.exsherpa.util.FormatValidator;
 import bgaebalja.exsherpa.util.TimeSelector;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,14 +21,18 @@ public class GetExamResponse {
     private String subjectName;
     private String timeLimit;
     private int size;
+    private boolean isCached;
     private GetCollectionsResponse getCollectionsResponse;
     private GetExaminationHistoriesResponse getExaminationHistoriesResponse;
+    private GetExaminationHistoryResponse cachedExaminationHistoryResponse;
 
     @Builder
     private GetExamResponse(
             Long id, String username, String className, String grade, String examName,
-            String subjectName, String timeLimit, int size, GetCollectionsResponse getCollectionsResponse,
-            GetExaminationHistoriesResponse getExaminationHistoriesResponse
+            String subjectName, String timeLimit, int size, boolean isCached,
+            GetCollectionsResponse getCollectionsResponse,
+            GetExaminationHistoriesResponse getExaminationHistoriesResponse,
+            GetExaminationHistoryResponse cachedExaminationHistoryResponse
     ) {
         this.id = id;
         this.username = username;
@@ -35,8 +42,10 @@ public class GetExamResponse {
         this.subjectName = subjectName;
         this.timeLimit = timeLimit;
         this.size = size;
+        this.isCached = isCached;
         this.getCollectionsResponse = getCollectionsResponse;
         this.getExaminationHistoriesResponse = getExaminationHistoriesResponse;
+        this.cachedExaminationHistoryResponse = cachedExaminationHistoryResponse;
     }
 
     public static GetExamResponse from(Exam exam) {
@@ -57,6 +66,45 @@ public class GetExamResponse {
                 .build();
     }
 
+    public static GetExamResponse from(Exam exam, ExaminationHistory examinationHistory) {
+        String className = FormatConverter.parseClassName(exam.getUser().getClazz());
+        String timeLimit = TimeSelector.selectTimeLimit(exam);
+
+        return GetExamResponse.builder()
+                .id(exam.getId())
+                .username(exam.getUser().getUsername())
+                .className(className)
+                .grade(exam.getUser().getGrade())
+                .examName(exam.getExamName())
+                .subjectName(exam.getBook().getSubject().getName())
+                .timeLimit(timeLimit)
+                .size(exam.getCollections().stream().map(Collection::getQuestionCount).reduce(0, Integer::sum))
+                .isCached(FormatValidator.hasValue(examinationHistory))
+                .getCollectionsResponse(GetCollectionsResponse.from(exam.getCollections()))
+                .getExaminationHistoriesResponse(GetExaminationHistoriesResponse.from(exam.getExaminationHistories()))
+                .build();
+    }
+
+    public static GetExamResponse from(Exam exam, GetExaminationHistoryResponse cachedExaminationHistory) {
+        String className = FormatConverter.parseClassName(exam.getUser().getClazz());
+        String timeLimit = TimeSelector.selectTimeLimit(exam);
+
+        return GetExamResponse.builder()
+                .id(exam.getId())
+                .username(exam.getUser().getUsername())
+                .className(className)
+                .grade(exam.getUser().getGrade())
+                .examName(exam.getExamName())
+                .subjectName(exam.getBook().getSubject().getName())
+                .timeLimit(timeLimit)
+                .size(exam.getCollections().stream().map(Collection::getQuestionCount).reduce(0, Integer::sum))
+                .getCollectionsResponse(
+                        GetCollectionsResponse.from(exam.getCollections(), cachedExaminationHistory)
+                )
+                .getExaminationHistoriesResponse(GetExaminationHistoriesResponse.from(exam.getExaminationHistories()))
+                .build();
+    }
+
     public static GetExamResponse fromExams(Exam exam) {
         String className = FormatConverter.parseClassName(exam.getUser().getClazz());
         String timeLimit = TimeSelector.selectTimeLimit(exam);
@@ -73,5 +121,9 @@ public class GetExamResponse {
                 .getCollectionsResponse(GetCollectionsResponse.fromExams(exam.getCollections()))
                 .getExaminationHistoriesResponse(GetExaminationHistoriesResponse.from(exam.getExaminationHistories()))
                 .build();
+    }
+
+    public void addCacheData(GetExaminationHistoryResponse cachedExaminationHistoryResponse) {
+        this.cachedExaminationHistoryResponse = cachedExaminationHistoryResponse;
     }
 }

--- a/src/main/java/bgaebalja/exsherpa/exam/domain/GetExamsResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/domain/GetExamsResponse.java
@@ -17,6 +17,10 @@ public class GetExamsResponse {
         return new GetExamsResponse(exams.stream().map(GetExamResponse::fromExams).collect(Collectors.toList()));
     }
 
+    public static GetExamsResponse of(List<GetExamResponse> getExamResponses) {
+        return new GetExamsResponse(getExamResponses);
+    }
+
     public int size() {
         return getExamResponses.size();
     }

--- a/src/main/java/bgaebalja/exsherpa/exam/repository/ExamRepository.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/repository/ExamRepository.java
@@ -13,7 +13,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
 
     List<Exam> findByDeleteYnFalseAndOpenYnTrue();
 
-    List<Exam> findByUserIdAndCustomYnFalseAndDeleteYnFalseAndOpenYnTrue(Long userId);
+    List<Exam> findByCustomYnFalseAndDeleteYnFalseAndOpenYnTrue();
 
     List<Exam> findByUserIdAndCustomYnTrueAndDeleteYnFalseAndOpenYnTrue(Long userId);
 

--- a/src/main/java/bgaebalja/exsherpa/exam/service/ExamService.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/service/ExamService.java
@@ -5,7 +5,7 @@ import bgaebalja.exsherpa.exam.domain.Exam;
 import java.util.List;
 
 public interface ExamService {
-    List<Exam> getPastExams(String email);
+    List<Exam> getPastExams();
 
     List<Exam> getBsherpaExams(String email);
 

--- a/src/main/java/bgaebalja/exsherpa/exam/service/ExamServiceImpl.java
+++ b/src/main/java/bgaebalja/exsherpa/exam/service/ExamServiceImpl.java
@@ -22,10 +22,8 @@ public class ExamServiceImpl implements ExamService {
     private final UserRepository userRepository;
 
     @Override
-    public List<Exam> getPastExams(String email) {
-        Users user = userRepository.getUserWithRoles(email);
-
-        return examRepository.findByUserIdAndCustomYnFalseAndDeleteYnFalseAndOpenYnTrue(user.getId());
+    public List<Exam> getPastExams() {
+        return examRepository.findByCustomYnFalseAndDeleteYnFalseAndOpenYnTrue();
     }
 
     @Override

--- a/src/main/java/bgaebalja/exsherpa/examination/domain/ExaminationHistory.java
+++ b/src/main/java/bgaebalja/exsherpa/examination/domain/ExaminationHistory.java
@@ -4,9 +4,11 @@ import bgaebalja.exsherpa.audit.BaseGeneralEntity;
 import bgaebalja.exsherpa.exam.domain.Exam;
 import bgaebalja.exsherpa.user.domain.Users;
 import bgaebalja.exsherpa.util.MathComputer;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.Hibernate;
 
 import javax.persistence.*;
 import java.util.List;
@@ -40,6 +42,7 @@ public class ExaminationHistory extends BaseGeneralEntity {
     private Exam exam;
 
     @OneToMany(mappedBy = "examinationHistory", cascade = {PERSIST, MERGE, REMOVE}, fetch = FetchType.LAZY)
+    @JsonManagedReference
     private List<SolvedQuestion> solvedQuestions;
 
     @Builder
@@ -63,5 +66,14 @@ public class ExaminationHistory extends BaseGeneralEntity {
                 .user(user)
                 .exam(exam)
                 .build();
+    }
+
+    @PostLoad
+    private void init() {
+        Hibernate.initialize(solvedQuestions);
+    }
+
+    public void addSolvedQuestions(List<SolvedQuestion> solvedQuestions) {
+        this.solvedQuestions = solvedQuestions;
     }
 }

--- a/src/main/java/bgaebalja/exsherpa/examination/domain/SolvedQuestion.java
+++ b/src/main/java/bgaebalja/exsherpa/examination/domain/SolvedQuestion.java
@@ -3,6 +3,7 @@ package bgaebalja.exsherpa.examination.domain;
 import bgaebalja.exsherpa.audit.BaseGeneralEntity;
 import bgaebalja.exsherpa.question.domain.Question;
 import bgaebalja.exsherpa.util.FormatConverter;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,6 +37,7 @@ public class SolvedQuestion extends BaseGeneralEntity {
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "examination_id")
+    @JsonBackReference
     private ExaminationHistory examinationHistory;
 
     @Builder

--- a/src/main/java/bgaebalja/exsherpa/examination/domain/SubmitResultRequest.java
+++ b/src/main/java/bgaebalja/exsherpa/examination/domain/SubmitResultRequest.java
@@ -8,6 +8,7 @@ import java.util.List;
 public class SubmitResultRequest {
     private String email;
     private String examId;
+    private String isCache;
     private List<AnswerRequest> answerRequests;
 
     public short size() {

--- a/src/main/java/bgaebalja/exsherpa/examination/service/ExaminationService.java
+++ b/src/main/java/bgaebalja/exsherpa/examination/service/ExaminationService.java
@@ -8,6 +8,10 @@ import java.util.List;
 public interface ExaminationService {
     int registerResult(SubmitResultRequest submitResultRequest);
 
+    ExaminationHistory registerCacheData(SubmitResultRequest submitResultRequest);
+
+    ExaminationHistory getCachedExaminationHistory(String email, Long examId);
+
     List<ExaminationHistory> getSolvedExaminationHistories();
 
     List<ExaminationHistory> getSolvedExaminationHistories(String email);

--- a/src/main/java/bgaebalja/exsherpa/examination/service/ExaminationServiceImpl.java
+++ b/src/main/java/bgaebalja/exsherpa/examination/service/ExaminationServiceImpl.java
@@ -3,6 +3,7 @@ package bgaebalja.exsherpa.examination.service;
 import bgaebalja.exsherpa.exam.domain.Exam;
 import bgaebalja.exsherpa.exam.service.ExamService;
 import bgaebalja.exsherpa.examination.domain.ExaminationHistory;
+import bgaebalja.exsherpa.examination.domain.SolvedQuestion;
 import bgaebalja.exsherpa.examination.domain.SubmitResultRequest;
 import bgaebalja.exsherpa.examination.repository.ExaminationRepository;
 import bgaebalja.exsherpa.exception.UserNotFoundException;
@@ -11,6 +12,8 @@ import bgaebalja.exsherpa.user.domain.Users;
 import bgaebalja.exsherpa.user.repository.UserRepository;
 import bgaebalja.exsherpa.util.FormatConverter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,11 +21,12 @@ import javax.persistence.EntityManager;
 import java.util.List;
 
 import static bgaebalja.exsherpa.exception.ExceptionMessage.USER_NOT_FOUND_EXCEPTION_MESSAGE;
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 import static org.springframework.transaction.annotation.Isolation.READ_UNCOMMITTED;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(isolation = READ_UNCOMMITTED, timeout = 20)
+@Transactional(isolation = READ_UNCOMMITTED, readOnly = true, timeout = 20)
 public class ExaminationServiceImpl implements ExaminationService {
     private final ExaminationRepository examinationRepository;
     private final ExamService examService;
@@ -31,8 +35,18 @@ public class ExaminationServiceImpl implements ExaminationService {
 
     private final EntityManager entityManager;
 
+    private static final String CREATE_EXAMINATION_KEY
+            = "#submitResultRequest.email + '_' + #submitResultRequest.examId";
+    private static final String CREATE_KEY_CONDITION = "#submitResultRequest != null";
+
+    private static final String GET_EXAMINATION_KEY = "#email + '_' + #examId";
+    private static final String GET_KEY_CONDITION = "#email != null && #examId != null";
+
+    private static final String KEY_VALUE = "examination";
+    private static final String UNLESS_CONDITION = "#result == null";
 
     @Override
+    @Transactional(isolation = READ_COMMITTED, timeout = 15)
     public int registerResult(SubmitResultRequest submitResultRequest) {
         String email = submitResultRequest.getEmail();
         Users user = userRepository.findByUserId(email)
@@ -48,6 +62,30 @@ public class ExaminationServiceImpl implements ExaminationService {
                         user.getId()
                 )
                 .size();
+    }
+
+    @Override
+    @Transactional(isolation = READ_UNCOMMITTED, timeout = 15)
+    @CachePut(
+            key = CREATE_EXAMINATION_KEY, condition = CREATE_KEY_CONDITION, unless = UNLESS_CONDITION, value = KEY_VALUE
+    )
+    public ExaminationHistory registerCacheData(SubmitResultRequest submitResultRequest) {
+        String email = submitResultRequest.getEmail();
+        Users user = userRepository.findByUserId(email)
+                .orElseThrow(() -> new UserNotFoundException(String.format(USER_NOT_FOUND_EXCEPTION_MESSAGE, email)));
+        Exam exam = examService.getExam(FormatConverter.parseToLong(submitResultRequest.getExamId()));
+        ExaminationHistory examinationHistory = ExaminationHistory.from(submitResultRequest, user, exam);
+        List<SolvedQuestion> solvedQuestions
+                = solvedQuestionService.registerCachedSolvedQuestions(submitResultRequest.getAnswerRequests(), examinationHistory);
+        examinationHistory.addSolvedQuestions(solvedQuestions);
+
+        return examinationHistory;
+    }
+
+    @Override
+    @Cacheable(key = GET_EXAMINATION_KEY, condition = GET_KEY_CONDITION, unless = UNLESS_CONDITION, value = KEY_VALUE)
+    public ExaminationHistory getCachedExaminationHistory(String email, Long examId) {
+        return null;
     }
 
     @Override

--- a/src/main/java/bgaebalja/exsherpa/hibernate/HibernateCollectionIdResolver.java
+++ b/src/main/java/bgaebalja/exsherpa/hibernate/HibernateCollectionIdResolver.java
@@ -1,0 +1,65 @@
+package bgaebalja.exsherpa.hibernate;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import lombok.NoArgsConstructor;
+import org.hibernate.collection.internal.*;
+
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.util.*;
+
+@NoArgsConstructor
+public class HibernateCollectionIdResolver extends TypeIdResolverBase {
+
+    @Override
+    public String idFromValue(Object value) {
+        if (value instanceof PersistentArrayHolder) {
+            return Array.class.getName();
+        }
+
+        if (value instanceof PersistentBag || value instanceof PersistentIdentifierBag
+                || value instanceof PersistentList) {
+            return List.class.getName();
+        }
+
+        if (value instanceof PersistentSortedMap) {
+            return TreeMap.class.getName();
+        }
+
+        if (value instanceof PersistentSortedSet) {
+            return TreeSet.class.getName();
+        }
+
+        if (value instanceof PersistentMap) {
+            return HashMap.class.getName();
+        }
+
+        if (value instanceof PersistentSet) {
+            return HashSet.class.getName();
+        }
+
+        return value.getClass().getName();
+    }
+
+    @Override
+    public String idFromValueAndType(Object value, Class<?> suggestedType) {
+        return idFromValue(value);
+    }
+
+    @Override
+    public JavaType typeFromId(DatabindContext ctx, String id) throws IOException {
+        try {
+            return ctx.getConfig().constructType(Class.forName(id));
+        } catch (ClassNotFoundException e) {
+            throw new UnsupportedOperationException(e);
+        }
+    }
+
+    @Override
+    public JsonTypeInfo.Id getMechanism() {
+        return JsonTypeInfo.Id.CLASS;
+    }
+}

--- a/src/main/java/bgaebalja/exsherpa/hibernate/HibernateCollectionMixIn.java
+++ b/src/main/java/bgaebalja/exsherpa/hibernate/HibernateCollectionMixIn.java
@@ -1,0 +1,9 @@
+package bgaebalja.exsherpa.hibernate;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonTypeIdResolver(value = HibernateCollectionIdResolver.class)
+public class HibernateCollectionMixIn {
+}

--- a/src/main/java/bgaebalja/exsherpa/question/domain/GetQuestionResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/question/domain/GetQuestionResponse.java
@@ -1,5 +1,6 @@
 package bgaebalja.exsherpa.question.domain;
 
+import bgaebalja.exsherpa.examination.domain.GetSolvedQuestionResponse;
 import bgaebalja.exsherpa.option.domain.GetOptionsResponse;
 import bgaebalja.exsherpa.option.domain.Option;
 import bgaebalja.exsherpa.util.ContentExtractor;
@@ -72,6 +73,44 @@ public class GetQuestionResponse {
 
         if (FormatValidator.hasValue(html)) {
             ContentExtractor.extractBodyContent(html, totalContent);
+        }
+
+        boolean isSubjective = question.getQuestionType().isSubjective();
+        GetOptionsResponse getOptionsResponse = null;
+        if (!isSubjective) {
+            List<Option> options = question.getOptions();
+            getOptionsResponse = addOptions(options, getOptionsResponse);
+        }
+
+        return GetQuestionResponse.builder()
+                .id(question.getId())
+                .itemId(question.getItemId())
+                .content(totalContent.toString())
+                .url(question.getUrl())
+                .descriptionUrl(question.getDescriptionUrl())
+                .questionType(question.getQuestionType())
+                .getOptionsResponse(getOptionsResponse)
+                .difficulty(question.getDifficulty())
+                .answer(question.getAnswer())
+                .answerUrl(question.getAnswerUrl())
+                .errorReportCount(question.getErrorReportCount())
+                .blockYn(question.isBlockYn())
+                .placementNumber(question.getPlacementNumber())
+                .largeChapterCode(question.getLargeChapterCode())
+                .largeChapterName(question.getLargeChapterName())
+                .mediumChapterCode(question.getMediumChapterCode())
+                .smallChapterCode(question.getSmallChapterCode())
+                .topicChapterCode(question.getTopicChapterCode())
+                .isSubjective(isSubjective)
+                .build();
+    }
+
+    public static GetQuestionResponse from(Question question, GetSolvedQuestionResponse cachedSolvedQuestion) {
+        String html = question.getHtml();
+        StringBuilder totalContent = new StringBuilder();
+
+        if (FormatValidator.hasValue(html)) {
+            ContentExtractor.extractBodyContent(html, totalContent, cachedSolvedQuestion.getSubmittedAnswer());
         }
 
         boolean isSubjective = question.getQuestionType().isSubjective();

--- a/src/main/java/bgaebalja/exsherpa/question/domain/GetQuestionsResponse.java
+++ b/src/main/java/bgaebalja/exsherpa/question/domain/GetQuestionsResponse.java
@@ -1,7 +1,10 @@
 package bgaebalja.exsherpa.question.domain;
 
+import bgaebalja.exsherpa.examination.domain.GetSolvedQuestionResponse;
+import bgaebalja.exsherpa.examination.domain.GetSolvedQuestionsResponse;
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,6 +20,25 @@ public class GetQuestionsResponse {
         return new GetQuestionsResponse(
                 questions.stream().map(GetQuestionResponse::from).collect(Collectors.toList())
         );
+    }
+
+    public static GetQuestionsResponse from(
+            List<Question> questions, GetSolvedQuestionsResponse cachedSolvedQuestionsResponse
+    ) {
+        List<GetQuestionResponse> getQuestionResponses = new ArrayList<>();
+        for (int i = 0; i < questions.size(); i++) {
+            for (
+                    GetSolvedQuestionResponse getSolvedQuestionResponse
+                    : cachedSolvedQuestionsResponse.getGetSolvedQuestionResponses()
+            ) {
+                if (questions.get(i).getId().equals(getSolvedQuestionResponse.getQuestionId())) {
+                    getQuestionResponses.add(GetQuestionResponse.from(questions.get(i), getSolvedQuestionResponse));
+                    break;
+                }
+            }
+        }
+
+        return new GetQuestionsResponse(getQuestionResponses);
     }
 
     public static GetQuestionsResponse fromExams(List<Question> questions) {

--- a/src/main/java/bgaebalja/exsherpa/question/domain/Question.java
+++ b/src/main/java/bgaebalja/exsherpa/question/domain/Question.java
@@ -3,7 +3,6 @@ package bgaebalja.exsherpa.question.domain;
 import bgaebalja.exsherpa.audit.BaseGeneralEntity;
 import bgaebalja.exsherpa.collection.domain.Collection;
 import bgaebalja.exsherpa.option.domain.Option;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,13 +32,11 @@ public class Question extends BaseGeneralEntity {
     // enum으로 저장
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    @JsonDeserialize(using = QuestionTypeDeserializer.class)
     private QuestionType questionType;
 
     // enum으로 저장
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    @JsonDeserialize(using = DifficultyDeserializer.class)
     private Difficulty difficulty;
 
     @Column(name = "description_url", nullable = false)

--- a/src/main/java/bgaebalja/exsherpa/solvedquestion/service/SolvedQuestionService.java
+++ b/src/main/java/bgaebalja/exsherpa/solvedquestion/service/SolvedQuestionService.java
@@ -9,5 +9,7 @@ import java.util.List;
 public interface SolvedQuestionService {
     void registerSolvedQuestions(List<AnswerRequest> answerRequests, ExaminationHistory examinationHistory);
 
+    List<SolvedQuestion> registerCachedSolvedQuestions(List<AnswerRequest> answerRequests, ExaminationHistory examinationHistory);
+
     SolvedQuestion getSolvedQuestion(Long id);
 }

--- a/src/main/java/bgaebalja/exsherpa/solvedquestion/service/SolvedQuestionServiceImpl.java
+++ b/src/main/java/bgaebalja/exsherpa/solvedquestion/service/SolvedQuestionServiceImpl.java
@@ -51,6 +51,27 @@ public class SolvedQuestionServiceImpl implements SolvedQuestionService {
     }
 
     @Override
+    public List<SolvedQuestion> registerCachedSolvedQuestions(
+            List<AnswerRequest> answerRequests, ExaminationHistory examinationHistory
+    ) {
+        List<SolvedQuestion> solvedQuestions = new ArrayList<>();
+        short questionNumber = 0;
+        for (AnswerRequest answerRequest : answerRequests) {
+            String questionId = answerRequest.getQuestionId();
+            Question question
+                    = questionRepository.findById(FormatConverter.parseToLong(questionId))
+                    .orElseThrow(
+                            () -> new QuestionNotFoundException(
+                                    String.format(QUESTION_NOT_FOUND_EXCEPTION_MESSAGE, questionId)
+                            )
+                    );
+            solvedQuestions.add(SolvedQuestion.from(++questionNumber, answerRequest, question, examinationHistory));
+        }
+
+        return solvedQuestions;
+    }
+
+    @Override
     public SolvedQuestion getSolvedQuestion(Long id) {
         return solvedQuestionRepository.findByIdAndDeleteYnFalse(id).orElseThrow(
                 () -> new SolvedQuestionNotFoundException(

--- a/src/main/java/bgaebalja/exsherpa/util/ContentExtractor.java
+++ b/src/main/java/bgaebalja/exsherpa/util/ContentExtractor.java
@@ -14,6 +14,25 @@ public class ContentExtractor {
         }
     }
 
+    public static void extractBodyContent(String html, StringBuilder totalContent, String cachedAnswer) {
+        String startTag = "<body>";
+        String endTag = "</body>";
+        String inputClassTag = "class=\"input_question_text_box\"";
+        String inputReplacement
+                = "<input class=\"input_question_text_box\" style=\"width : 100%; border-style : none; "
+                + "background-color : transparent; text-align : center;\" type=\"text\" maxlength=\"200\" value=\""
+                + (cachedAnswer.equals("미응답") ? "" : cachedAnswer) + "\">";
+
+        int startIndex = html.indexOf(startTag);
+        int endIndex = html.lastIndexOf(endTag);
+
+        if (startIndex != -1 && endIndex != -1) {
+            String bodyContent = html.substring(startIndex + startTag.length(), endIndex);
+            bodyContent = bodyContent.replaceAll("<input\\s+[^>]*" + inputClassTag + "[^>]*>", inputReplacement);
+            totalContent.append(bodyContent.trim()).append("\n");
+        }
+    }
+
     public static String createOption(int index) {
         return "<div class=\"paragraph\" style=\"border-left:0.2mm none;border-right:0.2mm none;border-top:0.2mm none;border-bottom:0.2mm none;text-indent: 0px;margin-left: 0px;margin-right: 0px;\">\n" +
                 "   <span class=\"txt \"></span><span class=\"txt \">" + index + "번 선택</span>\n" +

--- a/src/main/webapp/WEB-INF/views/exam/exam-view.jsp
+++ b/src/main/webapp/WEB-INF/views/exam/exam-view.jsp
@@ -10,9 +10,13 @@
 <%@ page import="bgaebalja.exsherpa.passage.domain.GetPassagesResponse" %>
 <%@ page import="bgaebalja.exsherpa.question.domain.GetQuestionsResponse" %>
 <%@ page import="bgaebalja.exsherpa.option.domain.GetOptionsResponse" %>
+<%@ page import="com.fasterxml.jackson.databind.ObjectMapper" %>
+<%@ page import="bgaebalja.exsherpa.examination.domain.GetSolvedQuestionResponse" %>
 
 <%
     GetExamResponse getExamResponse = (GetExamResponse) request.getAttribute("getExamResponse");
+    String email = session.getAttribute("email").toString();
+    boolean hasCachedData = FormatValidator.hasValue(getExamResponse.getCachedExaminationHistoryResponse());
 %>
 
 <html lang="ko">
@@ -168,7 +172,7 @@
                 <span class="txt">남은<br>시간</span>
                 <span class="time-txt" id="timer"><%= getExamResponse.getTimeLimit() %>:00</span>
             </div>
-            <a href="javascript:completeExam('<%= session.getAttribute("email") %>');" class="btn-submit">최종제출</a>
+            <a href="javascript:completeExam('<%= email %>');" class="btn-submit">최종제출</a>
         </div>
     </div>
     <div class="container">
@@ -186,6 +190,7 @@
                 </div>
             </div>
 
+            <input type="hidden" id="user_email" value="<%= email %>">
             <input type="hidden" name="exam_id"
                    value="<%= getExamResponse.getId() %>">
             <div class="swiper mySwiper">
@@ -204,10 +209,24 @@
                                 int endIndex = startIndex + getQuestionsResponse.size() - 1;
                                 for (int j = 0; j < getQuestionsResponse.size(); j++) {
                                     ++previousIndex;
+                                    Long questionId = getQuestionsResponse.get(j).getId();
+                                    String submittedAnswer = "";
+                                    boolean isChecked = false;
+
+                                    if (hasCachedData) {
+                                        for (
+                                                GetSolvedQuestionResponse solvedQuestion : getExamResponse.getCachedExaminationHistoryResponse().getGetSolvedQuestionsResponse().getGetSolvedQuestionResponses()
+                                        ) {
+                                            if (solvedQuestion.getQuestionId().equals(questionId)) {
+                                                submittedAnswer = solvedQuestion.getSubmittedAnswer().equals("미응답") ? "" : solvedQuestion.getSubmittedAnswer();
+                                                isChecked = true;
+                                                break;
+                                            }
+                                        }
+                                    }
                     %>
-                    <div class="swiper-slide" id="item<%= getQuestionsResponse.get(j).getId() %>"
-                         data-question-id="<%= getQuestionsResponse.get(j).getId() %>">
-                        <input type="hidden" name="question_id" value="<%= getQuestionsResponse.get(j).getId() %>">
+                    <div class="swiper-slide" id="item<%= questionId %>" data-question-id="<%= questionId %>">
+                        <input type="hidden" name="question_id" value="<%= questionId %>">
                         <input type="hidden" name="original_answer"
                                value="<%= getQuestionsResponse.get(j).getAnswer() %>">
                         <div class="page type01">
@@ -215,11 +234,11 @@
                                 <div class="question type01">
                                     <div class="left">
                                         <div class="passage">
-                                            <span>문제 <%= startIndex %> <%= getQuestionsResponse.size() > 1 ? " ~ " + endIndex : ""%></span>
+                                            <span>문제 <%= startIndex %> <%= getQuestionsResponse.size() > 1 ? " ~ " + endIndex : "" %></span>
                                             <%
                                                 for (int k = 0; k < getPassagesResponse.size(); k++) {
                                             %>
-                                            <img src="<%= getCollectionsResponse.get(i).getGetPassagesResponse().get(k).getUrl()%>">
+                                            <img src="<%= getCollectionsResponse.get(i).getGetPassagesResponse().get(k).getUrl() %>">
                                             <%
                                                 }
                                             %>
@@ -236,23 +255,25 @@
                                         %>
                                         <div class="subjective-answer">
                                             <input type="text" class="input_question_text_box"
-                                                   name="subjective_answer_<%= getQuestionsResponse.get(j).getId() %>"
-                                                   placeholder="답변을 입력하세요" style="width: 100%; margin-top: 10px;">
+                                                   name="subjective_answer_<%= questionId %>"
+                                                   placeholder="답변을 입력하세요" style="width: 100%; margin-top: 10px;"
+                                                   value="<%= isChecked ? submittedAnswer : "" %>">
                                         </div>
                                         <%
                                             }
                                         } else {
-                                            GetOptionsResponse getOptionsResponse
-                                                    = getQuestionsResponse.get(j).getGetOptionsResponse();
+                                            GetOptionsResponse getOptionsResponse = getQuestionsResponse.get(j).getGetOptionsResponse();
                                             for (int l = 0; l < getOptionsResponse.size(); l++) {
+                                                boolean optionChecked = isChecked && submittedAnswer.equals(getOptionsResponse.get(l).getOptionNo());
                                         %>
                                         <ul class="answer-input-type radio">
                                             <li>
-                                                <input type="radio"
-                                                       name="answer_<%= getQuestionsResponse.get(j).getId() %>"
+                                                <input type="radio" name="answer_<%= questionId %>"
                                                        id="answer_radio0<%= getOptionsResponse.get(l).getOptionNo() %>_<%= previousIndex %>"
-                                                       value="<%= previousIndex %>">
-                                                <label for="answer_radio0<%= getOptionsResponse.get(l).getOptionNo() %>_<%= previousIndex %>"><%= getOptionsResponse.get(l).getOptionNo() %>
+                                                       value="<%= getOptionsResponse.get(l).getOptionNo() %>"
+                                                    <%= optionChecked ? "checked" : "" %>>
+                                                <label for="answer_radio0<%= getOptionsResponse.get(l).getOptionNo() %>_<%= previousIndex %>">
+                                                    <%= getOptionsResponse.get(l).getOptionNo() %>
                                                 </label>
                                                 <%= getOptionsResponse.get(l).getHtml() %>
                                             </li>
@@ -271,66 +292,63 @@
                         }
                     } else {
                         for (int j = 0; j < getQuestionsResponse.size(); j++) {
-                            if (getQuestionsResponse.get(j).isSubjective()) {
+                            ++previousIndex;
+                            Long questionId = getQuestionsResponse.get(j).getId();
+                            String submittedAnswer = "";
+                            boolean isChecked = false;
+
+                            if (hasCachedData) {
+                                for (GetSolvedQuestionResponse solvedQuestion : getExamResponse.getCachedExaminationHistoryResponse().getGetSolvedQuestionsResponse().getGetSolvedQuestionResponses()) {
+                                    if (solvedQuestion.getQuestionId().equals(questionId)) {
+                                        submittedAnswer = solvedQuestion.getSubmittedAnswer().equals("미응답") ? "" : solvedQuestion.getSubmittedAnswer();
+                                        isChecked = true;
+                                        break;
+                                    }
+                                }
+                            }
                     %>
-                    <div class="swiper-slide" id="item<%= getQuestionsResponse.get(j).getId() %>"
-                         data-question-id="<%= getQuestionsResponse.get(j).getId() %>">
-                        <input type="hidden" name="question_id" value="<%= getQuestionsResponse.get(j).getId() %>">
+                    <div class="swiper-slide" id="item<%= questionId %>" data-question-id="<%= questionId %>">
+                        <input type="hidden" name="question_id" value="<%= questionId %>">
                         <input type="hidden" name="original_answer"
                                value="<%= getQuestionsResponse.get(j).getAnswer() %>">
                         <div class="page">
                             <div class="inner">
                                 <div class="question">
                                     <div class="top">
-                                        <span class="num"><%= ++previousIndex %></span>
-                                        <%= getQuestionsResponse.get(j).getContent() %>
+                                        <span class="num"><%= previousIndex %></span>
+                                        <span class="txt"><%= getQuestionsResponse.get(j).getContent() %></span>
                                     </div>
                                     <%
-                                        if (!getQuestionsResponse.get(j).getContent().contains("class=\"input_question_text_box\"")) {
+                                        if (getQuestionsResponse.get(j).isSubjective()) {
+                                            if (!getQuestionsResponse.get(j).getContent().contains("class=\"input_question_text_box\"")) {
                                     %>
                                     <div class="subjective-answer">
                                         <input type="text" class="input_question_text_box"
-                                               name="subjective_answer_<%= getQuestionsResponse.get(j).getId() %>"
-                                               placeholder="답변을 입력하세요" style="width: 100%; margin-top: 10px;">
+                                               name="subjective_answer_<%= questionId %>"
+                                               placeholder="답변을 입력하세요" style="width: 100%; margin-top: 10px;"
+                                               value="<%= isChecked ? submittedAnswer : "" %>">
                                     </div>
                                     <%
                                         }
-                                    %>
-                                </div>
-                            </div>
-                            <canvas class="sketchpad" style="cursor: crosshair;" width="1260" height="1216"></canvas>
-                        </div>
-                    </div>
-                    <%
-                    } else {
-                    %>
-                    <div class="swiper-slide" id="item<%= getQuestionsResponse.get(j).getId() %>"
-                         data-question-id="<%= getQuestionsResponse.get(j).getId() %>">
-                        <input type="hidden" name="question_id" value="<%= getQuestionsResponse.get(j).getId() %>">
-                        <input type="hidden" name="original_answer"
-                               value="<%= getQuestionsResponse.get(j).getAnswer() %>">
-                        <div class="page">
-                            <div class="inner">
-                                <div class="question">
-                                    <div class="top">
-                                        <span class="num"><%= ++previousIndex %></span>
-                                        <span class="txt"><%= getQuestionsResponse.get(j).getContent() %> <i> [4점]</i> </span>
-                                    </div>
-                                    <%
+                                    } else {
                                         GetOptionsResponse getOptionsResponse = getQuestionsResponse.get(j).getGetOptionsResponse();
-                                        for (int k = 0; k < getOptionsResponse.size(); k++) {
+                                        for (int l = 0; l < getOptionsResponse.size(); l++) {
+                                            boolean optionChecked = isChecked && submittedAnswer.equals(getOptionsResponse.get(l).getOptionNo());
                                     %>
                                     <ul class="answer-input-type radio">
                                         <li>
-                                            <input type="radio" name="answer_<%= getQuestionsResponse.get(j).getId() %>"
-                                                   id="answer_radio0<%= getOptionsResponse.get(k).getOptionNo() %>_<%= previousIndex %>"
-                                                   value="<%= previousIndex %>">
-                                            <label for="answer_radio0<%= getOptionsResponse.get(k).getOptionNo() %>_<%= previousIndex %>"><%= getOptionsResponse.get(k).getOptionNo() %>
+                                            <input type="radio" name="answer_<%= questionId %>"
+                                                   id="answer_radio0<%= getOptionsResponse.get(l).getOptionNo() %>_<%= previousIndex %>"
+                                                   value="<%= getOptionsResponse.get(l).getOptionNo() %>"
+                                                <%= optionChecked ? "checked" : "" %>>
+                                            <label for="answer_radio0<%= getOptionsResponse.get(l).getOptionNo() %>_<%= previousIndex %>">
+                                                <%= getOptionsResponse.get(l).getOptionNo() %>
                                             </label>
-                                            <%= getOptionsResponse.get(k).getHtml() %>
+                                            <%= getOptionsResponse.get(l).getHtml() %>
                                         </li>
                                     </ul>
                                     <%
+                                            }
                                         }
                                     %>
                                 </div>
@@ -339,7 +357,6 @@
                         </div>
                     </div>
                     <%
-                                    }
                                 }
                             }
                         }
@@ -446,6 +463,35 @@
         return answerExtractor.test();
     }
 
+    function sendAnswerToCache() {
+        const email = document.querySelector('#user_email').value;
+        const examId = document.querySelector('input[name="exam_id"]').value;
+        const extractedAnswers = extractAnswers();
+
+        fetch('/user/exam/submit', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                email: email,
+                examId: examId,
+                isCache: true,
+                answerRequests: extractedAnswers
+            }),
+        })
+            .then(response => {
+                if (!response.ok) {
+                    console.error("캐시 저장 실패: " + response.status);
+                }
+            })
+            .catch(error => {
+                console.error("오류:", error);
+            });
+    }
+
+    setInterval(sendAnswerToCache, 10000);
+
     function completeExam(email) {
         const examId = document.querySelector('input[name="exam_id"]').value;
         const extractedAnswers = extractAnswers();
@@ -460,6 +506,7 @@
                 body: JSON.stringify({
                     email: email,
                     examId: examId,
+                    isCache: false,
                     answerRequests: extractedAnswers
                 }),
             })
@@ -528,7 +575,6 @@
 
     const audioList = document.querySelectorAll('audio');
     if (audioList.length > 0) {
-        // alert("듣기는 한 번만 재생할 수 있으며, 페이지 이동 시 연계 문제가 아닐 경우 듣기가 자동으로 중지됩니다.");
     }
     audioList.forEach((item, index) => {
         item.controlsList.add('noplaybackrate');
@@ -575,5 +621,27 @@
             doNotAudio(this);
         });
     */
+</script>
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        const cachedData = <%= getExamResponse.getCachedExaminationHistoryResponse() != null ? new ObjectMapper().writeValueAsString(getExamResponse.getCachedExaminationHistoryResponse().getGetSolvedQuestionsResponse().getGetSolvedQuestionResponses()) : "[]" %>;
+
+        cachedData.forEach(question => {
+            const questionId = question.questionId;
+            const submittedAnswer = question.submittedAnswer;
+
+            if (question.isSubjective) {
+                const inputField = document.querySelector(`input[name="subjective_answer_${questionId}"]`);
+                if (inputField) {
+                    inputField.value = submittedAnswer;
+                }
+            } else {
+                const radioOption = document.querySelector(`input[name="answer_${questionId}"][value="${submittedAnswer}"]`);
+                if (radioOption) {
+                    radioOption.checked = true;
+                }
+            }
+        });
+    });
 </script>
 </html>

--- a/src/main/webapp/WEB-INF/views/user/exam/user-exam-subject.jsp
+++ b/src/main/webapp/WEB-INF/views/user/exam/user-exam-subject.jsp
@@ -130,12 +130,12 @@
                                                         <td>${exam.size}문항</td>
                                                         <td>
                                                             <c:choose>
-                                                                <c:when test="${exam.getExaminationHistoriesResponse.size() > 0 and exam.getExaminationHistoriesResponse.get(exam.getExaminationHistoriesResponse.size() - 1).solved eq 'true'}">
+                                                                <c:when test="${exam.getExaminationHistoriesResponse.size() > 0}">
                                                                     <a href="/user/exam/exam-view?exam_id=${exam.id}"
                                                                        class="startBtn"
                                                                        style="background-color: #ffae00;">재응시</a>
                                                                 </c:when>
-                                                                <c:when test="${exam.getExaminationHistoriesResponse.size() > 0 and exam.getExaminationHistoriesResponse.get(exam.getExaminationHistoriesResponse.size() - 1).solved eq 'false'}">
+                                                                <c:when test="${exam.cached eq 'true'}">
                                                                     <a href="/user/exam/exam-view?exam_id=${exam.id}"
                                                                        class="startBtn"
                                                                        style="background-color: #ee9490;">이어하기</a>
@@ -256,15 +256,15 @@
                                                         <td>${exam.size}문항</td>
                                                         <td>
                                                             <c:choose>
-                                                                <c:when test="${exam.getExaminationHistoriesResponse.size() > 0 and exam.getExaminationHistoriesResponse.get(exam.getExaminationHistoriesResponse.size() - 1).solved eq 'true'}">
+                                                                <c:when test="${exam.getExaminationHistoriesResponse.size() > 0}">
                                                                     <a href="/user/exam/exam-view?exam_id=${exam.id}"
                                                                        class="startBtn"
                                                                        style="background-color: #ffae00;">재응시</a>
                                                                 </c:when>
-                                                                <c:when test="${exam.getExaminationHistoriesResponse.size() > 0 and exam.getExaminationHistoriesResponse.get(exam.getExaminationHistoriesResponse.size() - 1).solved eq 'false'}">
-                                                                    <a href"/user/exam/exam-view?exam_id=${exam.id}"
-                                                                    class="startBtn"
-                                                                    style="background-color: #ee9490;">이어하기</a>
+                                                                <c:when test="${exam.cached eq 'true'}"> <a
+                                                                        href="/user/exam/exam-view?exam_id=${exam.id}&is_cached=true"
+                                                                        class="startBtn"
+                                                                        style="background-color: #ee9490;">이어하기</a>
                                                                 </c:when>
                                                                 <c:when test="${exam.getExaminationHistoriesResponse.size() == 0}">
                                                                     <a href="/user/exam/exam-view?exam_id=${exam.id}"


### PR DESCRIPTION
## resolve #113

## 작업내용
- Redis Cache 설정
- TTL을 하루로 설정
- 클라이언트에서 10초마다 답안 선택 데이터 전송
- 캐시 데이터 저장
- 시험지 목록을 불러 올 때 캐시 데이터가 존재하는 경우 이어하기 상태로 변경
- 이어하기 선택 시 캐시 데이터의 선택 답안 정보 불러 오기
- 페이지에 캐시 데이터의 선택 답안 정보 반영

## 배포
- [x] 성공
- [ ] 실패