### PR TITLE
[#126] 리포트 페이지에서 같은 시험지의 최신 데이터만 조회하도록 변경

### DIFF
--- a/src/main/java/bgaebalja/exsherpa/examination/repository/ExaminationRepository.java
+++ b/src/main/java/bgaebalja/exsherpa/examination/repository/ExaminationRepository.java
@@ -2,15 +2,24 @@ package bgaebalja.exsherpa.examination.repository;
 
 import bgaebalja.exsherpa.examination.domain.ExaminationHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ExaminationRepository extends JpaRepository<ExaminationHistory, Long> {
-    List<ExaminationHistory> findByUserIdAndSolvedYnTrueAndDeleteYnFalseOrderByModifiedAtAsc(Long userId);
+    @Query("SELECT eh FROM ExaminationHistory eh WHERE eh.user.id = :userId "
+            + "AND eh.solvedYn = true AND eh.deleteYn = false "
+            + "GROUP BY eh.exam.id ORDER BY MAX(eh.createdAt) DESC")
+    List<ExaminationHistory> findByUserIdAndSolvedYnTrueAndDeleteYnFalseOrderByCreatedAtDesc(
+            @Param("userId") Long userId
+    );
 
-    List<ExaminationHistory> findBySolvedYnTrueAndDeleteYnFalse();
+    List<ExaminationHistory> findBySolvedYnTrueAndDeleteYnFalseOrderByCreatedAtDesc();
 
-    List<ExaminationHistory> findByExamIdAndSolvedYnTrueAndDeleteYnFalse(Long examId);
+    List<ExaminationHistory> findByExamIdAndSolvedYnTrueAndDeleteYnFalseOrderByCreatedAtDesc(Long examId);
 
-    List<ExaminationHistory> findByExamIdAndUserIdAndSolvedYnTrueAndDeleteYnFalse(Long examId, Long userId);
+    List<ExaminationHistory> findByExamIdAndUserIdAndSolvedYnTrueAndDeleteYnFalseOrderByCreatedAtDesc(
+            Long examId, Long userId
+    );
 }

--- a/src/main/java/bgaebalja/exsherpa/examination/service/ExaminationServiceImpl.java
+++ b/src/main/java/bgaebalja/exsherpa/examination/service/ExaminationServiceImpl.java
@@ -58,7 +58,7 @@ public class ExaminationServiceImpl implements ExaminationService {
         solvedQuestionService.registerSolvedQuestions(submitResultRequest.getAnswerRequests(), examinationHistory);
         entityManager.refresh(examinationHistory);
 
-        return examinationRepository.findByUserIdAndSolvedYnTrueAndDeleteYnFalseOrderByModifiedAtAsc(
+        return examinationRepository.findByUserIdAndSolvedYnTrueAndDeleteYnFalseOrderByCreatedAtDesc(
                         user.getId()
                 )
                 .size();
@@ -90,21 +90,21 @@ public class ExaminationServiceImpl implements ExaminationService {
 
     @Override
     public List<ExaminationHistory> getSolvedExaminationHistories() {
-        return examinationRepository.findBySolvedYnTrueAndDeleteYnFalse();
+        return examinationRepository.findBySolvedYnTrueAndDeleteYnFalseOrderByCreatedAtDesc();
     }
 
     @Override
     public List<ExaminationHistory> getSolvedExaminationHistories(String email) {
         Users user = userRepository.findByUserId(email)
                 .orElseThrow(() -> new UserNotFoundException(String.format(USER_NOT_FOUND_EXCEPTION_MESSAGE, email)));
-        return examinationRepository.findByUserIdAndSolvedYnTrueAndDeleteYnFalseOrderByModifiedAtAsc(
+        return examinationRepository.findByUserIdAndSolvedYnTrueAndDeleteYnFalseOrderByCreatedAtDesc(
                 user.getId()
         );
     }
 
     @Override
     public List<ExaminationHistory> getSolvedExaminationHistoriesFromExam(Long examId) {
-        return examinationRepository.findByExamIdAndSolvedYnTrueAndDeleteYnFalse(examId);
+        return examinationRepository.findByExamIdAndSolvedYnTrueAndDeleteYnFalseOrderByCreatedAtDesc(examId);
     }
 
     @Override
@@ -112,6 +112,6 @@ public class ExaminationServiceImpl implements ExaminationService {
         Users user = userRepository.findByUserId(email)
                 .orElseThrow(() -> new UserNotFoundException(String.format(USER_NOT_FOUND_EXCEPTION_MESSAGE, email)));
 
-        return examinationRepository.findByExamIdAndUserIdAndSolvedYnTrueAndDeleteYnFalse(examId, user.getId());
+        return examinationRepository.findByExamIdAndUserIdAndSolvedYnTrueAndDeleteYnFalseOrderByCreatedAtDesc(examId, user.getId());
     }
 }


### PR DESCRIPTION
## resolve #126

## 변경사항
- 비즈니스 로직
- 쿼리문

## 배포
- [x] 성공
- [ ] 실패